### PR TITLE
Add support for SDK0Q55726 board

### DIFF
--- a/src/yoga-bios-unlock.c
+++ b/src/yoga-bios-unlock.c
@@ -22,6 +22,7 @@
 #define __BOARD_VENDOR "LENOVO"
 #define __BOARD_VERSION_00 "SDK0J40700 WIN  "
 #define __BOARD_VERSION_09 "SDK0J40709 WIN  "
+#define __BOARD_VERSION_26 "SDK0Q55726 WIN  "
 
 #define __CHASSIS_VERSION "Yoga Slim 7 14ARE05"
 
@@ -70,7 +71,8 @@ int is_yoga(void) {
   dmi_strings_t bios_version_27 = { .string = __BIOS_VERSION_27, .next = &bios_version_29 };
   dmi_strings_t board_name = { .string = __BOARD_NAME, .next = NULL };
   dmi_strings_t board_vendor = { .string = __BOARD_VENDOR, .next = NULL };
-  dmi_strings_t board_version_09 = { .string = __BOARD_VERSION_09, .next = NULL };
+  dmi_strings_t board_version_26 = { .string = __BOARD_VERSION_26, .next = NULL };
+  dmi_strings_t board_version_09 = { .string = __BOARD_VERSION_09, .next = &board_version_26 };
   dmi_strings_t board_version_00 = { .string = __BOARD_VERSION_00, .next = &board_version_09 };
   dmi_strings_t chassis_version = { .string = __CHASSIS_VERSION, .next = NULL };
 


### PR DESCRIPTION
Hi, I discovered that my laptop have different board version (`SDK0Q55726 WIN`) despite being the same model (Yoga Slim 7 14ARE05). After bypassing the check, I can verify that the BIOS is indeed unlocked and so far I have not encountered any error (about 1 month)

One of my friend also seems to have the same board version as me, and he have also confirmed that the tool works on his laptop.

dmidecode output
```
Handle 0x0000, DMI type 0, 26 bytes
BIOS Information
	Vendor: LENOVO
	Version: DMCN38WW
	Release Date: 01/18/2020
	Address: 0xE0000
	Runtime Size: 128 kB
	ROM Size: 16 MB
	Characteristics:
		PCI is supported
		BIOS is upgradeable
		BIOS shadowing is allowed
		Boot from CD is supported
		Selectable boot is supported
		EDD is supported
		Japanese floppy for NEC 9800 1.2 MB is supported (int 13h)
		Japanese floppy for Toshiba 1.2 MB is supported (int 13h)
		5.25"/360 kB floppy services are supported (int 13h)
		5.25"/1.2 MB floppy services are supported (int 13h)
		3.5"/720 kB floppy services are supported (int 13h)
		3.5"/2.88 MB floppy services are supported (int 13h)
		8042 keyboard services are supported (int 9h)
		CGA/mono video services are supported (int 10h)
		ACPI is supported
		USB legacy is supported
		BIOS boot specification is supported
		Targeted content distribution is supported
		UEFI is supported
	BIOS Revision: 1.38
	Firmware Revision: 1.29

Handle 0x0001, DMI type 1, 27 bytes
System Information
	Manufacturer: LENOVO
	Product Name: 82A2
	Version: Yoga Slim 7 14ARE05
	Serial Number: < removed >
	UUID: < removed >
	Wake-up Type: Power Switch
	SKU Number: LENOVO_MT_82A2_BU_idea_FM_Yoga Slim 7 14ARE05
	Family: Yoga Slim 7 14ARE05

```