### PR TITLE
check_dmi() fix

### DIFF
--- a/src/yoga-bios-unlock.c
+++ b/src/yoga-bios-unlock.c
@@ -51,7 +51,7 @@ int check_dmi(const char *file, dmi_strings_t *dmi) {
   }
 
   while (ptr != NULL) {
-    if (strcmp(ptr->string, buffer) == 0) {
+    if (memcmp(ptr->string, buffer, strlen(ptr->string)) == 0) {
       return 0;
     }
 


### PR DESCRIPTION
I have some junk after "SDK0J40688 WIN" in my board_version file. So strcmp() does not work.